### PR TITLE
Take into account Dublin Core elements for code list, update column info

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,19 +57,83 @@ Prerequisite: LibreOffice is installed, the minimum version needed is 24.2.5[^4]
 
 ### Editing genericode files
 
-The spreadsheet contains three sheets:
+The spreadsheet contains four sheets:
 
-1. Identification: displays the contents of `/CodeList/Identification`
-2. Columns: displays the contents of `/CodeList/ColumnSet`
-3. Values: displays the contents of `/CodeList/SimpleCodeList`
+1. Identification: displays the contents of `/gc:CodeList/Identification`
+2. Additional code list metadata: displays the contents of `/gc:CodeList/Annotation/Description`
+3. Columns: displays the contents of `/gc:CodeList/ColumnSet`
+4. Values: displays the contents of `/gc:CodeList/SimpleCodeList`
+
+### Profile of genericode
+
+Not all possibilities in the genericode standard are supported, and selected additional metadata element on the code list and its columns are supported.
 
 Conventions and limitations:
 
+- For sheets Identification and Additional code list metadata: the first column contains the element name and any attributes in the format `ElementName att1=value1,att2=value2`, e.g. `AlternateFormatLocationUri MimeType=text/csv` or `dcterms:description xml:lang`. Make sure not to have a space after the element name if the element should not have any attributes.
+- The Qualified DC XML Schemas are used for additional metadata, see also https://www.dublincore.org/schemas/xmls/, the properties from the `http://purl.org/dc/terms/` namespace are used.
+- For the code list itself, all `dcterms` properties are supported in `/gc:CodeList/Annotation/Description`, and `xml:lang` is  supported.
 - The `Id` attribute and the `ShortName` of a column are equal. If a column has another value as `ShortName` than the `Id` attribute in the genericode file, it will be replaced with the value of the `Id` attribute when the genericode file is saved.
-- The `Id` attribute is used for the column headers in sheet Values.
-- Undefined values must be encoded as an empty `Value` element.
+- For columns, only `@Id`, `@Use`, `Data/@Type`, `Data/@Lang` and `Annotation/Description/dcterms:description` are supported. `ShortName` is supported as well but is always set to the same value as the `Id` attribute and therefore not visible in the spreadsheet. `xml:lang` is not supported.
+- The `Id` attributes of the columns are used for the column headers in sheet Values.
+- An undefined value is encoded as an empty `Value` element.
 - The order of the `Value` elements must be the same as the order of the `Column` elements, if not, the transformation will be terminated and LibreOffice will display an error.
-- The Simple Dublin Core XML schema is used to encode the descriptions of the columns in the code list, see also https://www.dublincore.org/schemas/xmls/.
+
+An example:
+
+```xml
+<gc:CodeList xmlns:gc="http://docs.oasis-open.org/codelist/ns/genericode/1.0/" xmlns:dcterms="http://purl.org/dc/terms/">
+  <Annotation>
+    <Description>
+      <dcterms:description>Description of my code list.</dcterms:description>
+      <dcterms:language>en</dcterms:language>
+      <dcterms:license>https://path/to/license</dcterms:license>
+    </Description>
+  </Annotation>
+  <Identification>
+    <ShortName>mytype</ShortName>
+    <Version>1.0.0</Version>
+    <CanonicalUri>urn:uuid:08b6a53e-3d1b-42da-a6fb-4741a9ba5828</CanonicalUri>
+    <CanonicalVersionUri>urn:uuid:ceb73150-b5c4-4d61-8b18-ccdb02e1acde</CanonicalVersionUri>
+    <LocationUri>https://path/to/v1.0.0.mytype.gc</LocationUri>
+    <AlternateFormatLocationUri MimeType="text/csv">https://path/to/v1.0.0.mytype.csv</AlternateFormatLocationUri>
+    <AlternateFormatLocationUri MimeType="text/html">https://path/to/v1.0.0.mytype.html</AlternateFormatLocationUri>
+    <Agency>
+      <LongName>My organisation</LongName>
+    </Agency>
+  </Identification>
+  <ColumnSet>
+    <Column Id="code" Use="required">
+      <Annotation>
+        <Description>
+          <dcterms:description>allowed value in data</dcterms:description>
+        </Description>
+      </Annotation>
+      <ShortName>code</ShortName>
+      <Data Type="string"/>
+    </Column>
+    <Column Id="name" Use="required">
+      <Annotation>
+        <Description>
+          <dcterms:description>word or words that the thing is known by</dcterms:description>
+        </Description>
+      </Annotation>
+      <ShortName>name</ShortName>
+      <Data Type="string" Lang="en"/>
+    </Column>
+    <Key Id="key_code">
+      <ShortName>key_code</ShortName>
+      <ColumnRef Ref="code"/>
+    </Key>
+    <Key Id="key_name">
+      <ShortName>key_name</ShortName>
+      <ColumnRef Ref="name"/>
+    </Key>
+  </ColumnSet>
+  <SimpleCodeList/>
+</gc:CodeList>
+
+```
 
 ## Development
 

--- a/src/ods2gc.xsl
+++ b/src/ods2gc.xsl
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet
     version="1.0"
-    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:dcterms="http://purl.org/dc/terms/"
     xmlns:gc="http://docs.oasis-open.org/codelist/ns/genericode/1.0/"
     xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
     xmlns:str="http://exslt.org/strings"
     xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0"
     xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    exclude-result-prefixes="gc office table text"
+    exclude-result-prefixes="office table text"
     extension-element-prefixes="str">
 
     <xsl:output
@@ -18,17 +18,20 @@
         indent="yes" />
         
     <!-- This stylesheet assumes sheets with the following names -->
-    <xsl:param
+    <xsl:variable
         name="sheetNameIdentification"
         select="'Identification'" />
-    <xsl:param
+    <xsl:variable
+        name="sheetNameMetadata"
+        select="'Additional code list metadata'" />
+    <xsl:variable
         name="sheetNameColumnSet"
         select="'Columns'" />
-    <xsl:param
+    <xsl:variable
         name="sheetNameSimpleCodeList"
         select="'Values'" />
         
-    <!-- Create a lookup key with 
+    <!-- Create a lookup key of the first table row in the Values sheet with 
     - index: the position of the cell within the table row
     - value: the table cell
     The position() function cannot be used in this case, as it will always return 1.
@@ -36,52 +39,123 @@
     see also https://www.w3.org/TR/xslt-10/#key,
     therefore, the name of the sheet is hardcoded -->
     <xsl:key
-        name="valuesColumnPositionAndNameKey"
+        name="valuesTableColumnPositionKey"
         match="table:table[@table:name = 'Values']/table:table-row[position() = 1]/table:table-cell"
         use="count(preceding-sibling::table:table-cell) + 1" />
 
     <xsl:template match="/">
         <gc:CodeList xmlns:gc="http://docs.oasis-open.org/codelist/ns/genericode/1.0/">
-            <!-- This stylesheet assumes that the ODS file has sheets with the following names.
-            The values are hardcoded, as with XSLT 1.0, variables are not allowed in match,
-            see also https://www.w3.org/TR/xslt-10/#section-Defining-Template-Rules -->
-            <xsl:apply-templates select="//office:spreadsheet/table:table[@table:name = $sheetNameIdentification]" mode="identification" />
-            <xsl:apply-templates select="//office:spreadsheet/table:table[@table:name = $sheetNameColumnSet]" mode="columnset" />
-            <xsl:apply-templates select="//office:spreadsheet/table:table[@table:name = $sheetNameSimpleCodeList]" mode="values" />
+            <xsl:apply-templates
+                select="office:document/office:body/office:spreadsheet/table:table[@table:name = $sheetNameMetadata]"
+                mode="codeListMetadata" />
+            <xsl:apply-templates
+                select="office:document/office:body/office:spreadsheet/table:table[@table:name = $sheetNameIdentification]"
+                mode="identification" />
+            <xsl:apply-templates
+                select="office:document/office:body/office:spreadsheet/table:table[@table:name = $sheetNameColumnSet]"
+                mode="columnset" />
+            <xsl:apply-templates
+                select="office:document/office:body/office:spreadsheet/table:table[@table:name = $sheetNameSimpleCodeList]"
+                mode="values" />
         </gc:CodeList>
     </xsl:template>
-
-    <!-- Use the mode attribute and not a reference to $sheetNameIdentification in the match attribute,
-    as in XSLT 1.0 stylesheetss, it is an error for the value of the match attribute to contain a variable reference,
+    
+    <!-- Use the mode attribute and not a reference to a $sheetNameXXX variable in the match attribute,
+    as in XSLT 1.0 stylesheets, it is an error for the value of the match attribute to contain a variable reference,
     see also https://www.w3.org/TR/xslt-10/#section-Defining-Template-Rules -->
-    <xsl:template match="table:table" mode="identification">
-        <Identification>
-            <xsl:for-each select="table:table-row[not(starts-with(table:table-cell[position() = 1]/text:p, 'Agency/'))]">
+    <xsl:template
+        match="table:table"
+        mode="codeListMetadata">
+        <!-- Do not convert if sheet does not contain text -->
+        <xsl:if test="count(table:table-row/table:table-cell/text:p) &gt; 0">
+            <Annotation>
+                <Description>
+                    <xsl:for-each select="table:table-row">
+                        <xsl:call-template name="convertTableRowToXmlElement" />
+                    </xsl:for-each>
+                </Description>
+            </Annotation>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template name="convertTableRowToXmlElement">
+        <xsl:if test="count(table:table-cell/@table:number-columns-repeated) &gt; 0">
+            <xsl:message terminate="yes">
+                <xsl:text>This stylesheet does not take into account adjacent cells with the same content in sheets </xsl:text>
+                <xsl:value-of select="$sheetNameIdentification" />
+                <xsl:text> and </xsl:text>
+                <xsl:value-of select="$sheetNameMetadata" />
+                <xsl:text>.</xsl:text>
+            </xsl:message>
+        </xsl:if>
+        <xsl:variable
+            name="textFirstCell"
+            select="table:table-cell[position() = 1]/text:p" />
+        <xsl:variable
+            name="textSecondCell"
+            select="table:table-cell[position() = 2]/text:p" />
+        <xsl:choose>
+            <!-- no attributes; no child element, e.g. Version -->
+            <xsl:when test="not(contains($textFirstCell, ' ')) and not(contains($textFirstCell, '/'))">
                 <!-- Curly brackets are needed in the specification of the name of the element!
                 They inform the XSLT processor that the contents need to be treated as XPath. -->
-                <xsl:element name="{table:table-cell[position() = 1]/text:p}">
-                    <xsl:call-template name="tokenize-attributestring-and-create-attributes" />
-                    <xsl:value-of select="table:table-cell[position() = 2]/text:p" />
+                <xsl:element name="{$textFirstCell}">
+                    <xsl:value-of select="$textSecondCell" />
                 </xsl:element>
+            </xsl:when>
+            <!-- attributes; no child element, e.g. AlternateFormatLocationUri MimeType=text/csv -->
+            <xsl:when test="contains($textFirstCell, ' ') and not(contains(substring-before($textFirstCell, ' '), '/'))">
+                <!-- attributes -->
+                <xsl:element name="{substring-before($textFirstCell, ' ')}">
+                    <xsl:call-template name="tokenizeAttributestringAndCreateAttributes">
+                        <xsl:with-param
+                            name="attributestring"
+                            select="substring-after($textFirstCell, ' ')" />
+                    </xsl:call-template>
+                    <xsl:value-of select="$textSecondCell" />
+                </xsl:element>
+            </xsl:when>
+            <!-- no attributes; child element, e.g. Agency/LongName -->
+            <xsl:when test="not(contains($textFirstCell, ' ')) and contains($textFirstCell, '/')">
+                <xsl:element name="{substring-after($textFirstCell, '/')}">
+                    <xsl:value-of select="$textSecondCell" />
+                </xsl:element>
+            </xsl:when>
+            <!-- attributes; child element, e.g. Agency/LongName xml:lang=da -->
+            <xsl:when test="contains($textFirstCell, ' ') and contains(substring-before($textFirstCell, ' '), '/')">
+                <!-- attributes -->
+                <xsl:element name="{substring-after(substring-before($textFirstCell, ' '), '/')}">
+                    <xsl:call-template name="tokenizeAttributestringAndCreateAttributes">
+                        <xsl:with-param
+                            name="attributestring"
+                            select="substring-after($textFirstCell, ' ')" />
+                    </xsl:call-template>
+                    <xsl:value-of select="$textSecondCell" />
+                </xsl:element>
+            </xsl:when>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template
+        match="table:table"
+        mode="identification">
+        <Identification>
+            <xsl:for-each select="table:table-row[not(starts-with(table:table-cell[position() = 1]/text:p, 'Agency/'))]">
+                <xsl:call-template name="convertTableRowToXmlElement" />
             </xsl:for-each>
             <Agency>
                 <xsl:for-each select="table:table-row[starts-with(table:table-cell[position() = 1]/text:p, 'Agency/')]">
-                    <xsl:element name="{substring-after(table:table-cell[position() = 1]/text:p, 'Agency/')}">
-                        <xsl:call-template name="tokenize-attributestring-and-create-attributes" />
-                        <xsl:value-of select="table:table-cell[position() = 2]/text:p" />
-                    </xsl:element>
+                    <xsl:call-template name="convertTableRowToXmlElement" />
                 </xsl:for-each>
             </Agency>
         </Identification>
     </xsl:template>
 
-    <xsl:template name="tokenize-attributestring-and-create-attributes">
-        <xsl:variable
-            name="attributestring"
-            select="table:table-cell[position() = 3]/text:p" />
-        <xsl:if test="string-length($attributestring) > 0">
-            <!-- Attributes, if present, are written in the third column, in the style att1=value1, att2=value2, ... -->
-            <xsl:for-each select="str:tokenize($attributestring, ', ')">
+    <xsl:template name="tokenizeAttributestringAndCreateAttributes">
+        <xsl:param
+            name="attributestring" />
+        <xsl:if test="string-length($attributestring) &gt; 0">
+            <xsl:for-each select="str:tokenize($attributestring, ',')">
                 <xsl:attribute name="{substring-before(., '=')}">
                     <xsl:value-of select="substring-after(., '=')" />
                 </xsl:attribute>
@@ -89,77 +163,82 @@
         </xsl:if>
     </xsl:template>
 
-    <xsl:template match="table:table" mode="columnset">
+    <xsl:template
+        match="table:table"
+        mode="columnset">
+
+        <xsl:variable
+            name="positionId"
+            select="count(table:table-row[position() = 1]/table:table-cell[text:p/text() = '@Id']/preceding-sibling::table:table-cell) + 1" />
+        <xsl:variable
+            name="positionUse"
+            select="count(table:table-row[position() = 1]/table:table-cell[text:p/text() = '@Use']/preceding-sibling::table:table-cell) + 1" />
+        <xsl:variable
+            name="positionDataType"
+            select="count(table:table-row[position() = 1]/table:table-cell[text:p/text() = 'Data/@Type']/preceding-sibling::table:table-cell) + 1" />
+        <xsl:variable
+            name="positionDataLang"
+            select="count(table:table-row[position() = 1]/table:table-cell[text:p/text() = 'Data/@Lang']/preceding-sibling::table:table-cell) + 1" />
+        <xsl:variable
+            name="positionDctermsDescription"
+            select="count(table:table-row[position() = 1]/table:table-cell[text:p/text() = 'Annotation/Description/dcterms:description']/preceding-sibling::table:table-cell) + 1" />
+        <xsl:variable
+            name="positionKey"
+            select="count(table:table-row[position() = 1]/table:table-cell[text:p/text() = 'Key']/preceding-sibling::table:table-cell) + 1" />
+
         <ColumnSet>
-            <xsl:for-each select="table:table-row[position() > 1]">
-                <!-- 
-                 1: Id
-                 2: Use
-                 3: LongName (da)
-                 4: Description (da)
-                 5: LongName (en)
-                 6: Description (en)
-                 7: Data type
-                 8: Language of data
-                 9: Key
-                 -->
+            <xsl:for-each select="table:table-row[position() &gt; 1]">
+                <xsl:if test="count(table:table-cell/@table:number-columns-repeated) &gt; 0">
+                    <xsl:message terminate="yes">
+                        <xsl:text>This stylesheet does not take into account adjacent cells with the same content in sheet </xsl:text>
+                        <xsl:value-of select="$sheetNameColumnSet" />
+                        <xsl:text>.</xsl:text>
+                    </xsl:message>
+                </xsl:if>
+
                 <Column>
                     <xsl:attribute name="Id">
-                        <xsl:value-of select="table:table-cell[position() = 1]/text:p" />
+                        <xsl:value-of select="table:table-cell[position() = $positionId]/text:p" />
                     </xsl:attribute>
                     <xsl:attribute name="Use">
-                        <xsl:value-of select="table:table-cell[position() = 2]/text:p" />
+                        <xsl:value-of select="table:table-cell[position() = $positionUse]/text:p" />
                     </xsl:attribute>
-                    <xsl:if test="string-length(table:table-cell[position() = 4]/text:p) > 0 or string-length(table:table-cell[position() = 6]/text:p) > 0">
-                        <Annotation>
-                            <Description>
-                                <xsl:if test="string-length(table:table-cell[position() = 4]/text:p) > 0">
-                                    <dc:description xml:lang="da">
-                                        <xsl:value-of select="table:table-cell[position() = 4]/text:p" />
-                                    </dc:description>
-                                </xsl:if>
-                                <xsl:if test="string-length(table:table-cell[position() = 6]/text:p) > 0">
-                                    <dc:description xml:lang="en">
-                                        <xsl:value-of select="table:table-cell[position() = 6]/text:p" />
-                                    </dc:description>
-                                </xsl:if>
-                            </Description>
-                        </Annotation>
-                    </xsl:if>
+                    <Annotation>
+                        <Description>
+                            <dcterms:description>
+                                <xsl:value-of select="table:table-cell[position() = $positionDctermsDescription]/text:p" />
+                            </dcterms:description>
+                        </Description>
+                    </Annotation>
                     <ShortName>
-                        <!-- Use id attribute as shortname as well -->
-                        <xsl:value-of select="table:table-cell[position() = 1]/text:p" />
+                        <!-- Use id attribute as short name -->
+                        <xsl:value-of select="table:table-cell[position() = $positionId]/text:p" />
                     </ShortName>
-                    <LongName xml:lang="da">
-                        <xsl:value-of select="table:table-cell[position() = 3]/text:p" />
-                    </LongName>
-                    <LongName xml:lang="en">
-                        <xsl:value-of select="table:table-cell[position() = 5]/text:p" />
-                    </LongName>
                     <Data>
                         <xsl:attribute name="Type">
-                            <xsl:value-of select="table:table-cell[position() = 7]/text:p" />
+                            <xsl:value-of select="table:table-cell[position() = $positionDataType]/text:p" />
                         </xsl:attribute>
-                        <xsl:if test="string-length(table:table-cell[position() = 8]/text:p) > 0">
+                        <xsl:if test="string-length(table:table-cell[position() = $positionDataLang]/text:p) &gt; 0">
                             <xsl:attribute name="Lang">
-                                <xsl:value-of select="table:table-cell[position() = 8]/text:p" />
+                                <xsl:value-of select="table:table-cell[position() = $positionDataLang]/text:p" />
                             </xsl:attribute>
                         </xsl:if>
                     </Data>
                 </Column>
             </xsl:for-each>
-            <xsl:for-each select="table:table-row[position() > 1]">
-                <xsl:if test="string-length(table:table-cell[position() = 9]/text:p) > 0">
+
+            <xsl:for-each select="table:table-row[position() &gt; 1]">
+                <xsl:if test="string-length(table:table-cell[position() = $positionKey]/text:p) &gt; 0">
                     <Key>
                         <xsl:attribute name="Id">
-                            <xsl:value-of select="table:table-cell[position() = 9]/text:p" />
+                            <xsl:value-of select="table:table-cell[position() = $positionKey]/text:p" />
                         </xsl:attribute>
                         <ShortName>
-                            <xsl:value-of select="table:table-cell[position() = 9]/text:p" />
+                            <xsl:value-of select="table:table-cell[position() = $positionKey]/text:p" />
                         </ShortName>
                         <ColumnRef>
                             <xsl:attribute name="Ref">
-                                <xsl:value-of select="table:table-cell[position() = 1]/text:p" />
+                                <xsl:value-of select="table:table-cell[position() = $positionId]/text:p" />
                             </xsl:attribute>
                         </ColumnRef>
                     </Key>
@@ -167,34 +246,39 @@
             </xsl:for-each>
         </ColumnSet>
     </xsl:template>
-    
-    <xsl:template match="table:table" mode="values">
+
+    <xsl:template
+        match="table:table"
+        mode="values">
         <!-- The header row is used to create a lookup key, see above;
         process the actual data in the rest of the rows -->
         <SimpleCodeList>
-            <xsl:for-each select="table:table-row[position() > 1]">
-                <Row>
-                    <xsl:for-each select="table:table-cell">
-                        <xsl:call-template name="writeValue">
-                            <!-- Default value of table:number-columns-repeated is 1 according to the
-                            OpenDocument Format specification, see also
-                            https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part3-schema/OpenDocument-v1.3-os-part3-schema.html#__RefHeading__1418526_253892949 -->
-                            <xsl:with-param
-                                name="columnPosition"
-                                select="count(preceding-sibling::table:table-cell[not(@table:number-columns-repeated)]) + sum(preceding-sibling::table:table-cell/@table:number-columns-repeated) + 1" />
-                            <xsl:with-param name="noOfRepetitions">
-                                <xsl:choose>
-                                    <xsl:when test="count(@table:number-columns-repeated) = 1">
-                                        <xsl:value-of select="@table:number-columns-repeated" />
-                                    </xsl:when>
-                                    <xsl:otherwise>
-                                        <xsl:value-of select="1" />
-                                    </xsl:otherwise>
-                                </xsl:choose>
-                            </xsl:with-param>
-                        </xsl:call-template>
-                    </xsl:for-each>
-                </Row>
+            <xsl:for-each select="table:table-row[position() &gt; 1]">
+                <!-- Do not take into account empty rows (rows with only whitespace will be converted though) -->
+                <xsl:if test="count(table:table-cell/text:p) &gt; 0">
+                    <Row>
+                        <xsl:for-each select="table:table-cell">
+                            <xsl:call-template name="writeValue">
+                                <!-- Default value of table:number-columns-repeated is 1 according to the
+                                OpenDocument Format specification, see also
+                                https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part3-schema/OpenDocument-v1.3-os-part3-schema.html#__RefHeading__1418526_253892949 -->
+                                <xsl:with-param
+                                    name="columnPosition"
+                                    select="count(preceding-sibling::table:table-cell[not(@table:number-columns-repeated)]) + sum(preceding-sibling::table:table-cell/@table:number-columns-repeated) + 1" />
+                                <xsl:with-param name="noOfRepetitions">
+                                    <xsl:choose>
+                                        <xsl:when test="count(@table:number-columns-repeated) = 1">
+                                            <xsl:value-of select="@table:number-columns-repeated" />
+                                        </xsl:when>
+                                        <xsl:otherwise>
+                                            <xsl:value-of select="1" />
+                                        </xsl:otherwise>
+                                    </xsl:choose>
+                                </xsl:with-param>
+                            </xsl:call-template>
+                        </xsl:for-each>
+                    </Row>
+                </xsl:if>
             </xsl:for-each>
         </SimpleCodeList>
     </xsl:template>
@@ -210,17 +294,17 @@
         Value element corresponding to every column. -->
         <Value>
             <xsl:attribute name="ColumnRef">
-            	<xsl:value-of select="key('valuesColumnPositionAndNameKey', $columnPosition)/text:p" />
+            	<xsl:value-of select="key('valuesTableColumnPositionKey', $columnPosition)/text:p" />
             </xsl:attribute>
             <!-- In this transformation, an undefined value (an empty string in the cell) (only applicable in optional columns)
             is always written as a Value element that does not contain a SimpleValue element. -->
-            <xsl:if test="string-length(normalize-space(text:p)) > 0">
+            <xsl:if test="string-length(normalize-space(text:p)) &gt; 0">
                 <SimpleValue>
                     <xsl:value-of select="text:p" />
                 </SimpleValue>
             </xsl:if>
         </Value>
-        <xsl:if test="$noOfRepetitions > 1">
+        <xsl:if test="$noOfRepetitions &gt; 1">
             <!-- This is a recursive template -->
             <xsl:call-template name="writeValue">
                 <xsl:with-param


### PR DESCRIPTION
- Use Dublin Core elements from the `http://purl.org/dc/terms/` namespace
- Update info about columns: restrict to `@Id`, `@Use`, `Data/@Type`, `Data/@Lang` and `Annotation/Description/dcterms:description` (and `ShortName`)
- Update the way XML attributes in the code list info sheets are displayed